### PR TITLE
docs: Update copyright text in source files

### DIFF
--- a/example/build_flex.py
+++ b/example/build_flex.py
@@ -2,7 +2,10 @@
 """
 An example of cloning, configuring, building, and installing software.
 
-Copyright The shell-logger Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from pathlib import Path

--- a/example/hello_world_html.py
+++ b/example/hello_world_html.py
@@ -2,7 +2,10 @@
 """
 A simple example.
 
-Copyright The shell-logger Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from pathlib import Path

--- a/example/hello_world_html_and_console.py
+++ b/example/hello_world_html_and_console.py
@@ -2,7 +2,10 @@
 """
 A simple example, sending output to the log file and console.
 
-Copyright The shell-logger Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from pathlib import Path

--- a/example/hello_world_html_with_stats.py
+++ b/example/hello_world_html_with_stats.py
@@ -2,7 +2,10 @@
 """
 A simple example, capturing various system statistics.
 
-Copyright The shell-logger Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from pathlib import Path

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 """
-Copyright The shell-logger Authors.
+Setup file for the ``shell-logger`` package.
+
+To install, simply ``python3 -m pip install .`` in the repository root.
+
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 import setuptools

--- a/shell_logger/__init__.py
+++ b/shell_logger/__init__.py
@@ -1,7 +1,10 @@
 """
 The ``shell_logger`` package.
 
-Copyright The shell-logger Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from .shell_logger import ShellLogger, ShellLoggerDecoder, ShellLoggerEncoder

--- a/shell_logger/abstract_method.py
+++ b/shell_logger/abstract_method.py
@@ -2,7 +2,10 @@
 """
 Provides the :class:`AbstractMethod` exception.
 
-Copyright The shell-logger Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 import inspect

--- a/shell_logger/html_utilities.py
+++ b/shell_logger/html_utilities.py
@@ -2,7 +2,10 @@
 """
 Various utitlities for building the HTML log file.
 
-Copyright The shell-logger Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from collections.abc import Iterable, Mapping

--- a/shell_logger/shell.py
+++ b/shell_logger/shell.py
@@ -2,7 +2,10 @@
 """
 Provides the :class:`Shell` class.
 
-Copyright The shell-logger Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from __future__ import annotations

--- a/shell_logger/shell_logger.py
+++ b/shell_logger/shell_logger.py
@@ -2,7 +2,10 @@
 """
 Provides the :class:`ShellLogger` class, along with some helpers.
 
-Copyright The shell-logger Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from __future__ import annotations

--- a/shell_logger/stats_collector.py
+++ b/shell_logger/stats_collector.py
@@ -2,7 +2,10 @@
 """
 Provides the various means of collecting machine statistics.
 
-Copyright The shell-logger Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from __future__ import annotations

--- a/shell_logger/trace.py
+++ b/shell_logger/trace.py
@@ -2,7 +2,10 @@
 """
 Provides the means of collecting various trace data.
 
-Copyright The shell-logger Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from __future__ import annotations

--- a/test/test_shell_logger.py
+++ b/test/test_shell_logger.py
@@ -1,7 +1,10 @@
 """
 The unit test suite for the ``shell_logger`` package.
 
-Copyright The shell-logger Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from _pytest.capture import CaptureFixture


### PR DESCRIPTION
Per guidance from Sandia Technology Transfer, the recommended text from the Linux Foundation is insufficient for our purposes.