### PR TITLE
docs: Move copyright/license text to comments

### DIFF
--- a/example/build_flex.py
+++ b/example/build_flex.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
 An example of cloning, configuring, building, and installing software.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from pathlib import Path
 from shell_logger import ShellLogger
 

--- a/example/hello_world_html.py
+++ b/example/hello_world_html.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
 A simple example.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from pathlib import Path
 from shell_logger import ShellLogger
 

--- a/example/hello_world_html_and_console.py
+++ b/example/hello_world_html_and_console.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
 A simple example, sending output to the log file and console.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from pathlib import Path
 from shell_logger import ShellLogger
 

--- a/example/hello_world_html_with_stats.py
+++ b/example/hello_world_html_with_stats.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
 A simple example, capturing various system statistics.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from pathlib import Path
 from shell_logger import ShellLogger
 

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,14 @@
 Setup file for the ``shell-logger`` package.
 
 To install, simply ``python3 -m pip install .`` in the repository root.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 import setuptools
 
 if __name__ == "__main__":

--- a/shell_logger/__init__.py
+++ b/shell_logger/__init__.py
@@ -1,12 +1,13 @@
 """
 The ``shell_logger`` package.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from .shell_logger import ShellLogger, ShellLoggerDecoder, ShellLoggerEncoder
 
 __all__ = ["ShellLogger", "ShellLoggerDecoder", "ShellLoggerEncoder"]

--- a/shell_logger/abstract_method.py
+++ b/shell_logger/abstract_method.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
 Provides the :class:`AbstractMethod` exception.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 import inspect
 
 

--- a/shell_logger/html_utilities.py
+++ b/shell_logger/html_utilities.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
 Various utitlities for building the HTML log file.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from collections.abc import Iterable, Mapping
 from datetime import datetime
 import pkgutil

--- a/shell_logger/shell.py
+++ b/shell_logger/shell.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
 Provides the :class:`Shell` class.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from __future__ import annotations
 import fcntl
 from io import StringIO

--- a/shell_logger/shell_logger.py
+++ b/shell_logger/shell_logger.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
 Provides the :class:`ShellLogger` class, along with some helpers.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from __future__ import annotations
 from .shell import Shell
 from .stats_collector import stats_collectors

--- a/shell_logger/stats_collector.py
+++ b/shell_logger/stats_collector.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
 Provides the various means of collecting machine statistics.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from __future__ import annotations
 from .abstract_method import AbstractMethod
 from abc import abstractmethod

--- a/shell_logger/trace.py
+++ b/shell_logger/trace.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
 Provides the means of collecting various trace data.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from __future__ import annotations
 from .abstract_method import AbstractMethod
 from abc import abstractmethod

--- a/test/test_shell_logger.py
+++ b/test/test_shell_logger.py
@@ -1,12 +1,13 @@
 """
 The unit test suite for the ``shell_logger`` package.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 from _pytest.capture import CaptureFixture
 from _pytest.monkeypatch import MonkeyPatch
 from inspect import stack


### PR DESCRIPTION
**Type:  Documentation**

## Description
In all the source files, move the copyright and license text from the module docstring to comments immediately below it.  This is to remove this text from automatic processing of docstrings when building the documentation.

## Related Issues/PRs
<!--
Mention any issues or pull requests that this PR is related to.  E.g.,
* Closes #456.
* Related to #123.
* Etc.
-->

## Motivation
<!--
If this wasn't covered in any related issues linked above, why was this change
needed?  What does it do for us?
-->

## Implementation Details
<!--
If appropriate, why did you implement things the way you did?  What
alternatives did you consider?  Are there any gotchas to be aware of?  How does
this set us up to be in a better place in the future?  Etc.
-->

## Screenshots/Recordings
<!--
If applicable, visually demonstrate the behavior before and after your changes.
-->


## Testing
<!--
Indicate what testing you added to cover your changes, and what testing you ran
to ensure your changes are working as expected.
-->


## Documentation
<!--
Indicate how and where you've updated the documentation to cover your changes.
-->
