### PR TITLE
chore: Remove commitizen pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,6 @@ repos:
           args: [ --fix ]
         - id: ruff-format
 
-    # - repo: https://github.com/commitizen-tools/commitizen
-    #   rev: v3.15.0
-    #   hooks:
-    #       - id: commitizen
-    #       - id: commitizen-branch
-    #         stages: [push]
-
     # - repo: https://github.com/pre-commit/mirrors-mypy
     #   rev: v1.8.0
     #   hooks:


### PR DESCRIPTION
In order to enable a faster development workflow, remove the commitizen pre-commit hook to allow commits messages that don't adhere to the Conventional Commits specification.  Commit messages are still checked in the Continuous Integration workflow, though, so a branch will need to be clean before merging.