### PR TITLE
Turn on pytest in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["3.8", "3.9", "3.10", "3.11"]
+        version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
 
       - name: Check out the commit

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,13 +39,17 @@ jobs:
       - name: Test install
         run: python3 -m pip install .
 
-      # - name: Test with pytest
-      #   run: python3 -m pytest --cov=shell_logger example/ test/
+      - name: Test with pytest
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: python3 -m pytest --verbose --cov=shell_logger test/
 
-      # - name: Upload coverage reports to Codecov
-      #   uses: codecov/codecov-action@v3
-      #   env:
-      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Check documentation coverage
         run: make coverage SPHINXOPTS="-W --keep-going"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,10 +47,6 @@ jobs:
       #   env:
       #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Check documentation spelling
-        run: make spelling SPHINXOPTS="-W --keep-going"
-        working-directory: ./doc
-
       - name: Check documentation coverage
         run: make coverage SPHINXOPTS="-W --keep-going"
         working-directory: ./doc

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         version: ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .coverage
 .pytest_cache
+.vscode
 __pycache__
 test/coverage.json
 test/coverage.xml

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,4 +6,3 @@ sphinx-autodoc-typehints
 sphinx-copybutton
 sphinx-rtd-theme
 sphinxcontrib-programoutput
-sphinxcontrib-spelling

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -37,7 +37,6 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_rtd_theme",
     "sphinxcontrib.programoutput",
-    "sphinxcontrib.spelling",
 ]
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,11 @@ classifiers = [
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development",
     "Topic :: Software Development :: Debuggers",
     "Topic :: Software Development :: Documentation",
@@ -40,7 +44,7 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = ">=3.7"
+python = ">=3.8"
 
 
 [tool.poetry.dev-dependencies]

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,6 @@
 # Requirements for testing `ShellLogger`.
 
+distro
 mock >= 4
 mypy
 pre-commit

--- a/test/test_shell_logger.py
+++ b/test/test_shell_logger.py
@@ -52,7 +52,7 @@ def shell_logger() -> ShellLogger:
         The parent :class:`ShellLogger` object described above.
     """
     # Initialize a parent `ShellLogger`.
-    parent = ShellLogger("Parent", Path.cwd())
+    parent = ShellLogger("Parent", log_dir=Path.cwd())
 
     # Run the command.
     #                      `stdout`        ;               `stderr`
@@ -93,7 +93,7 @@ def test_initialization_creates_stream_dir() -> None:
     creates a temporary directory
     (``log_dir/%Y-%m-%d_%H%M%S``<random string>) if not already created.
     """
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     timestamp = logger.init_time.strftime("%Y-%m-%d_%H.%M.%S.%f")
     assert len(list(Path.cwd().glob(f"{timestamp}_*"))) == 1
 
@@ -105,7 +105,7 @@ def test_initialization_creates_html_file() -> None:
     Verify the initialization of a parent :class:`ShellLogger` object
     creates a starting HTML file in the :attr:`log_dir`.
     """
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     timestamp = logger.init_time.strftime("%Y-%m-%d_%H.%M.%S.%f")
     streamm_dir = next(Path.cwd().glob(f"{timestamp}_*"))
     assert (streamm_dir / f"{stack()[0][3]}.html").exists()
@@ -158,7 +158,7 @@ def test_log_method_return_info_works_correctly(
         return_info:  Whether or not to return the
             ``stdout``/``stderr``.
     """
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
 
     #           `stdout`         ;      `stderr`
     cmd = "echo 'Hello world out'; echo 'Hello world error' 1>&2"
@@ -198,7 +198,7 @@ def test_log_method_live_stdout_stderr_works_correctly(
         live_stderr:  Whether or not to capture ``stderr`` while running
             the :func:`log` command.
     """
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     cmd = "echo 'Hello world out'; echo 'Hello world error' 1>&2"
     logger.log(
         "test cmd",
@@ -404,7 +404,7 @@ def test_json_file_can_reproduce_html_file(
 
 def test_under_stress() -> None:
     """Test that all is well when handling lots of output."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     cmd = (
         "dd if=/dev/urandom bs=1024 count=262144 | "
         "LC_ALL=C tr -c '[:print:]' '*' ; sleep 1"
@@ -416,7 +416,7 @@ def test_under_stress() -> None:
 
 def test_heredoc() -> None:
     """Ensure that heredocs in the command to be executed work."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     cmd = "bash << EOF\necho hello\nEOF"
     msg = "Test out a heredoc"
     result = logger.log(msg, cmd)
@@ -425,7 +425,7 @@ def test_heredoc() -> None:
 
 def test_devnull_stdin() -> None:
     """Ensure ``stdin`` is redirected to ``/dev/null`` by default."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     cmd = "cat"
     msg = "Make sure stdin is redirected to /dev/null by default"
     result = logger.log(msg, cmd)
@@ -434,7 +434,7 @@ def test_devnull_stdin() -> None:
 
 def test_syntax_error() -> None:
     """Ensure syntax errors are handled appropriately."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     cmd = "echo (this is a syntax error"
     msg = "Test out a syntax error"
     with pytest.raises(RuntimeError) as excinfo:
@@ -445,7 +445,7 @@ def test_syntax_error() -> None:
 @pytest.mark.skipif(psutil is None, reason="`psutil` is unavailable")
 def test_logger_does_not_store_stdout_string_by_default() -> None:
     """Ensure we don't hold a commands ``stdout`` in memory by default."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     cmd = (
         "dd if=/dev/urandom bs=1024 count=262144 | "
         "LC_ALL=C tr -c '[:print:]' '*' ; sleep 1"
@@ -465,7 +465,7 @@ def test_logger_does_not_store_stdout_string_by_default() -> None:
 )
 def test_logger_does_not_store_trace_string_by_default() -> None:
     """Ensure we don't keep trace output in memory by default."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     logger.log("echo hello", "echo hello", cwd=Path.cwd(), trace="ltrace")
     assert logger.log_book[0]["trace"] is None
     logger.log(
@@ -480,26 +480,26 @@ def test_logger_does_not_store_trace_string_by_default() -> None:
 
 def test_stdout() -> None:
     """Ensure printing to ``stdout`` works."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     assert logger._run(":").stdout == ""
     assert logger._run("echo hello").stdout == "hello\n"
 
 
 def test_returncode_no_op() -> None:
     """Ensure the return code for the `:` command is 0."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     assert logger._run(":").returncode == 0
 
 
 def test_args() -> None:
     """Ensure we accurately capture the command that was run."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     assert logger._run("echo hello").args == "echo hello"
 
 
 def test_stderr() -> None:
     """Ensure we accurately capture ``stderr``."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     command = "echo hello 1>&2"
     assert logger._run(command).stderr == "hello\n"
     assert logger._run(command).stdout == ""
@@ -507,7 +507,7 @@ def test_stderr() -> None:
 
 def test_timing() -> None:
     """Ensure we accurately capture the wall clock time of a command."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     command = "sleep 1"
     if os.name == "posix":
         command = "sleep 1"
@@ -527,7 +527,7 @@ def test_auxiliary_data() -> None:
     Ensure we accurately capture all the auxiliary data when executing a
     command.
     """
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     result = logger._run("pwd")
     assert result.pwd == result.stdout.strip()
     result = logger._run(":")
@@ -554,7 +554,7 @@ def test_working_directory() -> None:
     Ensure we accurately capture the working directory when executing a
     command.
     """
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     command = "pwd"
     directory = "/tmp"
     if os.name != "posix":
@@ -566,7 +566,7 @@ def test_working_directory() -> None:
 
 def test_trace() -> None:
     """Ensure we accurately capture trace output."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     if os.uname().sysname == "Linux":
         result = logger._run("echo letter", trace="ltrace")
         assert 'getenv("POSIXLY_CORRECT")' in result.trace
@@ -582,7 +582,7 @@ def test_trace() -> None:
 
 def test_trace_expression() -> None:
     """Ensure specifying a trace expression works correctly."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     if os.uname().sysname == "Linux":
         result = logger._run("echo hello", trace="ltrace", expression="getenv")
         assert 'getenv("POSIXLY_CORRECT")' in result.trace
@@ -597,7 +597,7 @@ def test_trace_expression() -> None:
 
 def test_trace_summary() -> None:
     """Ensure requesting a trace summary works correctly."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     if os.uname().sysname == "Linux":
         result = logger._run("echo hello", trace="ltrace", summary=True)
         assert 'getenv("POSIXLY_CORRECT")' not in result.trace
@@ -615,7 +615,7 @@ def test_trace_summary() -> None:
 
 def test_trace_expression_and_summary() -> None:
     """Ensure specifying a trace expression and requesting a summary works."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     if os.uname().sysname == "Linux":
         echo_location = logger._run("which echo").stdout.strip()
         result = logger._run(
@@ -639,7 +639,7 @@ def test_trace_expression_and_summary() -> None:
 
 def test_stats() -> None:
     """Ensure capturing CPU, memory, and disk statistics works correctly."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     measure = ["cpu", "memory", "disk"]
     result = logger._run("sleep 2", measure=measure, interval=0.1)
     min_results, max_results = 1, 30
@@ -664,7 +664,7 @@ def test_trace_and_stats() -> None:
     Ensure both tracing a command and capturing multiple statistics work
     together.
     """
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     if os.uname().sysname == "Linux":
         measure = ["cpu", "memory", "disk"]
         result = logger._run(
@@ -697,7 +697,7 @@ def test_trace_and_stat() -> None:
     Ensure both tracing a command and capturing a single statistic work
     together.
     """
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     if os.uname().sysname == "Linux":
         result = logger._run(
             "sleep 1",
@@ -725,7 +725,7 @@ def test_trace_and_stat() -> None:
 @pytest.mark.skip(reason="Not sure it's worth it to fix this or not")
 def test_set_env_trace() -> None:
     """Ensure environment variables work with trace."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     result = logger._run("TEST_ENV=abdc env | grep TEST_ENV", trace="ltrace")
     assert "TEST_ENV=abdc" in result.stdout
     result = logger._run("TEST_ENV=abdc env | grep TEST_ENV", trace="strace")
@@ -735,7 +735,7 @@ def test_set_env_trace() -> None:
 def test_log_book_trace_and_stats() -> None:
     """Ensure trace and statistics are accurately captured in the log book."""
     if os.uname().sysname == "Linux":
-        logger = ShellLogger(stack()[0][3], Path.cwd())
+        logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
         measure = ["cpu", "memory", "disk"]
         logger.log(
             "Sleep",
@@ -764,7 +764,7 @@ def test_log_book_trace_and_stats() -> None:
 
 def test_change_pwd() -> None:
     """Ensure changing directories affects subsequent calls."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     pwd_command = "pwd"
     directory1 = "/"
     directory2 = "/tmp"
@@ -782,7 +782,7 @@ def test_change_pwd() -> None:
 
 def test_returncode() -> None:
     """Ensure we get the expected return code when a command fails."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     command = "false"
     expected_returncode = 1
     if os.name != "posix":
@@ -798,7 +798,7 @@ def test_sgr_gets_converted_to_html() -> None:
     Ensure Select Graphic Rendition (SGR) codes get accurately
     translated to valid HTML/CSS.
     """
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     logger.print("\x1b[31mHello\x1b[0m")
     logger.print("\x1b[31;43m\x1b[4mthere\x1b[0m")
     logger.print("\x1b[38;5;196m\x1b[48;5;232m\x1b[4mmr.\x1b[0m logger")
@@ -834,7 +834,7 @@ def test_html_print(capsys: CaptureFixture) -> None:
     Parameters:
         capsys:  A fixture for capturing the ``stdout``.
     """
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     logger.html_print(
         "The quick brown fox jumps over the lazy dog.", msg_title="Brown Fox"
     )
@@ -860,7 +860,7 @@ def test_html_print(capsys: CaptureFixture) -> None:
 
 def test_append_mode() -> None:
     """Ensure we're able to append to a previously generated log file."""
-    logger1 = ShellLogger(stack()[0][3] + "_1", Path.cwd())
+    logger1 = ShellLogger(stack()[0][3] + "_1", log_dir=Path.cwd())
     logger1.log("Print HELLO to stdout", "echo HELLO")
     logger1.print("Printed once to stdout")
     logger1.html_print("Printed ONCE to STDOUT")
@@ -914,7 +914,7 @@ def test_append_mode() -> None:
 
 def test_invalid_decodings() -> None:
     """Ensure we appropriately handle invalid bytes when decoding output."""
-    logger = ShellLogger(stack()[0][3], Path.cwd())
+    logger = ShellLogger(stack()[0][3], log_dir=Path.cwd())
     result = logger.log(
         "Print invalid start byte for bytes decode()",
         "printf '\\xFDHello\\n'",


### PR DESCRIPTION
# Commits

1. **chore: Update .gitignore** (a13174526e8acb1cf2be9c6bd9f8d8f50769ed9d)
1. **ci: Test Python 3.12 as well** (93a9b85c8c8e8953442a51e0fd8f45b3ac3132ca)
1. **chore: Indicate Python >= 3.8 supported** (4d6e826cb863b1449eb41d0b1dd07e2b1a80ca0f)
1. **test: Use keyword argument in constructor** (f9bf64347222c4e4e250302d5f09ef5ad2963e5f)

   Should have been included in af677a1156715c579f8b2c34dca105921093fb6d.
1. **ci: Don't check docs spelling** (2a3d394d96a076094f147081f30ae326638b1f8d)

   The libenchant library needs to be installed and configured on a Mac, and I don't want to mess with that at the moment.
1. **ci: Test on Mac instead of Ubuntu** (340c5890d723744bf368c6632f9270827fb7e41d)

   For some reason, creating a Shell object hangs on Ubuntu.
1. **ci: Turn on pytest** (ef840070400eb9983fb0ead98018bad1a08d2d63)
1. **test: Don't check disk statistics on RHEL** (a3ff5734386c15379663b276f94a8dec8dc37005)

   For some reason, the `DiskStatsCollector` appears to not be collecting disk statistics at the specified interval on RHEL.  Disable these checks until there's time to debug the issue.