### PR TITLE
chore!: Drop support for Python 3.8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
 
       - name: Harden Runner

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![pre-commit.ci Status](https://results.pre-commit.ci/badge/github/sandialabs/shell-logger/master.svg)](https://results.pre-commit.ci/latest/github/sandialabs/shell-logger/master)
 [![PyPI - Version](https://img.shields.io/pypi/v/shell-logger-sandialabs?label=PyPI)](https://pypi.org/project/shell-logger-sandialabs/)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/shell-logger-sandialabs?label=PyPI%20downloads)
-![Python Version](https://img.shields.io/badge/Python-3.8|3.9|3.10|3.11|3.12-blue.svg)
+![Python Version](https://img.shields.io/badge/Python-3.9|3.10|3.11|3.12-blue.svg)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 > **NOTICE:**  After using this package for a few years, we realized we'd

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -64,7 +64,7 @@ shell-logger
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/shell-logger-sandialabs?label=PyPI
    :target: https://pypi.org/project/shell-logger-sandialabs/
 .. |PyPI Downloads| image:: https://img.shields.io/pypi/dm/shell-logger-sandialabs?label=PyPI%20downloads
-.. |Python Version| image:: https://img.shields.io/badge/Python-3.8|3.9|3.10|3.11|3.12-blue.svg
+.. |Python Version| image:: https://img.shields.io/badge/Python-3.9|3.10|3.11|3.12-blue.svg
 .. |Ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
    :target: https://github.com/astral-sh/ruff
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/shell_logger/html_utilities.py
+++ b/shell_logger/html_utilities.py
@@ -13,7 +13,7 @@ from collections.abc import Iterable, Mapping
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Iterator, List, TextIO, Tuple, Union
+from typing import Iterator, TextIO, Union
 
 
 def nested_simplenamespace_to_dict(
@@ -157,7 +157,7 @@ def flatten(element: Union[str, bytes, Iterable]) -> Iterator[str]:
 
 
 def parent_logger_card_html(
-    name: str, *args: List[Iterator[str]]
+    name: str, *args: list[Iterator[str]]
 ) -> Iterator[str]:
     """
     Generate the HTML for a parent logger card.
@@ -212,7 +212,7 @@ def child_logger_card(log) -> Iterator[str]:
 
 
 def child_logger_card_html(
-    name: str, duration: str, *args: Union[Iterator[str], List[Iterator[str]]]
+    name: str, duration: str, *args: Union[Iterator[str], list[Iterator[str]]]
 ) -> Iterator[str]:
     """
     Generate the HTML for a child logger card.
@@ -480,7 +480,7 @@ def command_card(log: dict, stream_dir: Path) -> Iterator[str]:
 
 
 def time_series_plot(
-    cmd_id: str, data_tuples: List[Tuple[float, float]], series_title: str
+    cmd_id: str, data_tuples: list[tuple[float, float]], series_title: str
 ) -> Iterator[str]:
     """
     Create the HTML for a plot of time series data.
@@ -501,7 +501,7 @@ def time_series_plot(
 
 
 def disk_time_series_plot(
-    cmd_id: str, data_tuples: Tuple[float, float], volume_name: str
+    cmd_id: str, data_tuples: tuple[float, float], volume_name: str
 ) -> Iterator[str]:
     """
     Generate a time series plot of disk usage.
@@ -530,7 +530,7 @@ def disk_time_series_plot(
 
 
 def stat_chart_card(
-    labels: List[str], data: List[float], title: str, identifier: str
+    labels: list[str], data: list[float], title: str, identifier: str
 ) -> Iterator[str]:
     """
     Create the HTML for a two-dimensional plot.
@@ -676,7 +676,7 @@ def output_block_html(
 
 def split_template(
     template: str, split_at: str, **kwargs
-) -> Tuple[str, str, str]:
+) -> tuple[str, str, str]:
     """
     Subdivide a HTML template.
 
@@ -854,7 +854,7 @@ def sgr_4bit_color_and_style_to_html(sgr: str) -> str:
     return f'<span style="{sgr_to_css.get(sgr) or str()}">'
 
 
-def sgr_8bit_color_to_html(sgr_params: List[str]) -> str:  # noqa: PLR0911
+def sgr_8bit_color_to_html(sgr_params: list[str]) -> str:  # noqa: PLR0911
     """
     Convert 8-bit SGR colors to HTML.
 
@@ -894,7 +894,7 @@ def sgr_8bit_color_to_html(sgr_params: List[str]) -> str:  # noqa: PLR0911
     return "THIS SHOULD NEVER HAPPEN"
 
 
-def sgr_24bit_color_to_html(sgr_params: List[str]) -> str:
+def sgr_24bit_color_to_html(sgr_params: list[str]) -> str:
     """
     Convert 24-bit SGR colors to HTML.
 

--- a/shell_logger/html_utilities.py
+++ b/shell_logger/html_utilities.py
@@ -501,7 +501,7 @@ def time_series_plot(
 
 
 def disk_time_series_plot(
-    cmd_id: str, data_tuples: tuple[float, float], volume_name: str
+    cmd_id: str, data_tuples: list[tuple[float, float]], volume_name: str
 ) -> Iterator[str]:
     """
     Generate a time series plot of disk usage.

--- a/shell_logger/html_utilities.py
+++ b/shell_logger/html_utilities.py
@@ -866,6 +866,10 @@ def sgr_8bit_color_to_html(sgr_params: list[str]) -> str:  # noqa: PLR0911
 
     Returns:
         A HTML ``span`` with the appropriate CSS style.
+
+    Raises:
+        RuntimeError:  If the code somehow falls through all the `if`
+            blocks without returning.  This should never happen.
     """
     sgr_256 = int(sgr_params[2]) if len(sgr_params) > 2 else 0
     if sgr_256 < 0 or sgr_256 > 255 or not sgr_params:
@@ -891,7 +895,8 @@ def sgr_8bit_color_to_html(sgr_params: list[str]) -> str:  # noqa: PLR0911
             return sgr_4bit_color_and_style_to_html(str(40 + sgr_256))
         if sgr_256 < 16:
             return sgr_4bit_color_and_style_to_html(str(92 + sgr_256))
-    return "THIS SHOULD NEVER HAPPEN"
+    message = "THIS SHOULD NEVER HAPPEN"
+    raise RuntimeError(message)
 
 
 def sgr_24bit_color_to_html(sgr_params: list[str]) -> str:

--- a/shell_logger/shell.py
+++ b/shell_logger/shell.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from threading import Thread
 from time import time
 from types import SimpleNamespace
-from typing import IO, List, Optional, TextIO, Tuple
+from typing import IO, Optional, TextIO
 
 
 END_OF_READ = 4
@@ -262,7 +262,7 @@ class Shell:
         stdout_tee = [sys_stdout, stdout_io, stdout_path]
         stderr_tee = [sys_stderr, stderr_io, stderr_path]
 
-        def write(input_file: TextIO, output_files: List[TextIO]) -> None:
+        def write(input_file: TextIO, output_files: list[TextIO]) -> None:
             """
             Write an input to multiple outputs.
 
@@ -320,7 +320,7 @@ class Shell:
 
     def auxiliary_command(
         self, **kwargs
-    ) -> Tuple[Optional[str], Optional[str]]:
+    ) -> tuple[Optional[str], Optional[str]]:
         """
         Run auxiliary commands like `umask`, `pwd`, `env`, etc.
 

--- a/shell_logger/shell_logger.py
+++ b/shell_logger/shell_logger.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta
 from distutils import dir_util
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Iterator, List, Optional, Union
+from typing import Iterator, Optional, Union
 
 from .html_utilities import (
     append_html,
@@ -139,7 +139,7 @@ class ShellLogger:
         html_file: Optional[Path] = None,
         indent: int = 0,
         login_shell: bool = False,
-        log: Optional[List[object]] = None,
+        log: Optional[list[object]] = None,
         init_time: Optional[datetime] = None,
         done_time: Optional[datetime] = None,
         duration: Optional[str] = None,
@@ -179,7 +179,7 @@ class ShellLogger:
             generally be omitted.
         """
         self.name = name
-        self.log_book: List[Union[dict, ShellLogger]] = (
+        self.log_book: list[Union[dict, ShellLogger]] = (
             log if log is not None else []
         )
         self.init_time = datetime.now() if init_time is None else init_time
@@ -404,7 +404,7 @@ class ShellLogger:
         }
         self.log_book.append(log)
 
-    def to_html(self) -> Union[Iterator[str], List[Iterator[str]]]:
+    def to_html(self) -> Union[Iterator[str], list[Iterator[str]]]:
         """
         Convert the log entries to HTML.
 
@@ -591,7 +591,7 @@ class ShellLogger:
         s = int(result.wall / 1000) % 60
         log["duration"] = f"{h}h {m}m {s}s"
         log["return_code"] = result.returncode
-        log = {**log, **nested_simplenamespace_to_dict(result)}
+        log |= nested_simplenamespace_to_dict(result)
         self.log_book.append(log)
         return {
             "return_code": log["return_code"],

--- a/shell_logger/stats_collector.py
+++ b/shell_logger/stats_collector.py
@@ -13,7 +13,7 @@ from abc import abstractmethod
 from multiprocessing import Manager, Process
 from pathlib import Path
 from time import sleep, time
-from typing import List, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from .abstract_method import AbstractMethod
 
@@ -26,7 +26,7 @@ except ModuleNotFoundError:
     psutil = None
 
 
-def stats_collectors(**kwargs) -> List[StatsCollector]:
+def stats_collectors(**kwargs) -> list[StatsCollector]:
     """
     Generate stats collectors.
 
@@ -236,7 +236,7 @@ if psutil is not None:
             timestamp = round(time() * milliseconds_per_second)
             self.stats.append((timestamp, psutil.cpu_percent(interval=None)))
 
-        def unproxied_stats(self) -> List[Tuple[float, float]]:
+        def unproxied_stats(self) -> list[tuple[float, float]]:
             """
             Convert the statistics to standard Python data types.
 
@@ -277,7 +277,7 @@ if psutil is not None:
             timestamp = round(time() * milliseconds_per_second)
             self.stats.append((timestamp, psutil.virtual_memory().percent))
 
-        def unproxied_stats(self) -> List[Tuple[float, float]]:
+        def unproxied_stats(self) -> list[tuple[float, float]]:
             """
             Convert the statistics to standard Python data types.
 

--- a/test/test_shell_logger.py
+++ b/test/test_shell_logger.py
@@ -64,9 +64,11 @@ def shell_logger() -> ShellLogger:
     measure = ["cpu", "memory", "disk"]
     kwargs = {"measure": measure, "return_info": True, "interval": 0.1}
     if os.uname().sysname == "Linux":
-        kwargs.update(
-            {"trace": "ltrace", "expression": "setlocale", "summary": True}
-        )
+        kwargs |= {
+            "trace": "ltrace",
+            "expression": "setlocale",
+            "summary": True,
+        }
     else:
         print(
             f"Warning: uname is not 'Linux': {os.uname()}; ltrace not tested."


### PR DESCRIPTION
**Type:  Task**

## Description
* Use type-hinting out of the box in 3.9.
* Use new dictionary update syntax.
* Update the CI and docs accordingly.

## Motivation
The Python community no longer supports 3.8.

## Summary by Sourcery

Drop support for Python 3.8 and update the codebase to leverage Python 3.9 features, including type hinting and dictionary update syntax. Adjust CI and documentation to align with the new Python version support.

Enhancements:
- Utilize Python 3.9's new dictionary update syntax and type hinting features.

CI:
- Update CI configuration to remove Python 3.8 from the testing matrix.

Documentation:
- Update documentation to reflect the removal of Python 3.8 support.

Chores:
- Drop support for Python 3.8 across the codebase.