### PR TITLE
patch: Support Python 3.13

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        version: ["3.9", "3.10", "3.11", "3.12"]
+        version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
 
       - name: Harden Runner

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![pre-commit.ci Status](https://results.pre-commit.ci/badge/github/sandialabs/shell-logger/master.svg)](https://results.pre-commit.ci/latest/github/sandialabs/shell-logger/master)
 [![PyPI - Version](https://img.shields.io/pypi/v/shell-logger-sandialabs?label=PyPI)](https://pypi.org/project/shell-logger-sandialabs/)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/shell-logger-sandialabs?label=PyPI%20downloads)
-![Python Version](https://img.shields.io/badge/Python-3.9|3.10|3.11|3.12-blue.svg)
+![Python Version](https://img.shields.io/badge/Python-3.9|3.10|3.11|3.12|3.13-blue.svg)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 > **NOTICE:**  After using this package for a few years, we realized we'd

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -64,7 +64,7 @@ shell-logger
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/shell-logger-sandialabs?label=PyPI
    :target: https://pypi.org/project/shell-logger-sandialabs/
 .. |PyPI Downloads| image:: https://img.shields.io/pypi/dm/shell-logger-sandialabs?label=PyPI%20downloads
-.. |Python Version| image:: https://img.shields.io/badge/Python-3.9|3.10|3.11|3.12-blue.svg
+.. |Python Version| image:: https://img.shields.io/badge/Python-3.9|3.10|3.11|3.12|3.13-blue.svg
 .. |Ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
    :target: https://github.com/astral-sh/ruff
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development",
     "Topic :: Software Development :: Debuggers",
     "Topic :: Software Development :: Documentation",


### PR DESCRIPTION
**Type:  Task**

## Description
Test against Python 3.13 and add it to the list of supported versions.

## Motivation
Python 3.13 was released back in October.

## Summary by Sourcery

Add support for Python 3.13 by updating the CI configuration, documentation, and project metadata to include the new version.

CI:
- Add Python 3.13 to the CI testing matrix to ensure compatibility.

Documentation:
- Update README to reflect support for Python 3.13.