### PR TITLE
docs: Switch to `project_copyright`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,7 +13,7 @@ sys.path.append(str(Path.cwd().parent.parent.resolve() / "shell_logger"))
 # -- Project information -----------------------------------------------------
 
 project = "shell-logger"
-copyright = (  # noqa: A001
+project_copyright = (
     "2024, National Technology & Engineering Solutions of Sandia, LLC (NTESS)"
 )
 author = "Josh Braun, David Collins, Jason M. Gates"


### PR DESCRIPTION
**Type:  Documentation**

## Description
Using this alias means we're no longer overshadowing the `copyright` built-in, so we can remove the comment to ignore that Ruff linting rule.

## Summary by Sourcery

Documentation:
- Replace the `copyright` variable with `project_copyright` in the documentation configuration to avoid overshadowing the built-in `copyright` function.