### PR TITLE
docs: Downgrade Sphinx version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for building the `shell-logger` documentation.
 
-sphinx<=9.0.0
+sphinx<9.0.0
 sphinx-argparse
 sphinx-autodoc-typehints
 sphinx-copybutton


### PR DESCRIPTION
Should have been included in 30a5d86a367a2056e44e96a56d0c2847b040a5bc.
