### PR TITLE
docs: Unpin Sphinx version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for building the `shell-logger` documentation.
 
-sphinx<9.0.0
+sphinx
 sphinx-argparse
 sphinx-autodoc-typehints
 sphinx-copybutton


### PR DESCRIPTION
The various Sphinx extensions have been updated to deal with the breaking changes in 9.0.0.  This effectively reverts cbcf9c2cf1597fa1a02f2758a86e2a8c675f75c4 and
30a5d86a367a2056e44e96a56d0c2847b040a5bc.
